### PR TITLE
remove duplicate kdf feature from feature list

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,6 @@ With that (maybe incomple) list of features:
 - nonces and salts
 - signature & authentication (mac & digital signature)
 - encryption (block & stream ciphers)
-- key derivation functions (kdf)
 
 
 Github: https://github.com/funcool/buddy-core


### PR DESCRIPTION
I suspect "key derivation functions" and "key derivation algorithms"  are referring to the same set of features.