### PR TITLE
Update buddy dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/funcool/buddy"
   :license {:name "Apache 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[buddy/buddy-core "1.2.0" :exclusions [org.clojure/clojure]]
-                 [buddy/buddy-auth "1.4.1" :exclusions [org.clojure/clojure]]
+  :dependencies [[buddy/buddy-core "1.3.0" :exclusions [org.clojure/clojure]]
+                 [buddy/buddy-auth "2.0.0" :exclusions [org.clojure/clojure]]
                  [buddy/buddy-hashers "1.2.0" :exclusions [org.clojure/clojure]]
-                 [buddy/buddy-sign "1.5.0" :exclusions [org.clojure/clojure]]]
+                 [buddy/buddy-sign "2.0.0" :exclusions [org.clojure/clojure]]]
   :plugins [[lein-ancient "0.6.10"]]
   :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"])


### PR DESCRIPTION
bump buddy deps to their current version.

I'm waiting on 2 PR's in buddy sign if you want to coordinate with that. 

To buddy sign i'm adding a way to suppress expiration checks of token claims. The version provided by "buddy" now is 1.3 which lacks even the leeway option so i can't even put a large leeway to fake suppressing the token expiration.